### PR TITLE
Made load balancer provisioning optional even with multiple masters

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,13 +11,13 @@ This includes the masters, the workers and potentially a load balancer (a node w
 The module takes the following variables as input:
 
 - namespace: A string to namespace all the vm names (ie, `<vm name>-<namespace>`). If this variable is omitted, a namespace suffix will not be added.
-- masters_count: The number of masters to provision. If greater than 1, a load balancer will also be provisioned.
+- masters_count: The number of masters to provision.
 - masters_flavor_id: The id of the flavor the masters will have.
 - masters_security_groups: List of security groups to assign to the masters. Defaults to `["default"]`
 - workers_count: The number of workers to provision.
 - workers_flavor_id: The id of the flavor the workers will have.
 - workers_security_groups: List of security groups to assign to the workers. Defaults to `["default"]`
-- load_balancer_flavor_id: The id of the flavor the load balancer will have.
+- load_balancer_flavor_id: The id of the flavor the load balancer will have. If you do not wish to provision a load balancer, leave this value at its blank default.
 - load_balancer_security_groups: List of security groups to assign to the load balancer. Defaults to `["default"]`
 - image_id: ID of the image to use to provision all vms
 - network_name: Name of the network to connect all vms to
@@ -40,7 +40,7 @@ The module outputs the following variables as output:
   ip: <ip address of the master>
 }
 ```
-- load_balancer: id and ip of the load balancer taking the following format:
+- load_balancer: id and ip of the load balancer taking the following format (if a load balancer is not provisioned, the values will be the empty string):
 ```
 {
   id: <id of the master>

--- a/main.tf
+++ b/main.tf
@@ -47,7 +47,7 @@ data "template_cloudinit_config" "load_balancer_config" {
 }
 
 resource "openstack_compute_instance_v2" "load_balancer" {
-  count           = var.masters_count > 1 ? 1 : 0
+  count           = var.load_balancer_flavor_id != "" ? 1 : 0
   name            = var.namespace == "" ? "k8-masters-lb" : "k8-masters-lb-{var.namespace}"
   image_id        = var.image_id
   flavor_id       = var.load_balancer_flavor_id

--- a/output.tf
+++ b/output.tf
@@ -19,7 +19,7 @@ output "workers" {
 
 output "load_balancer" {
     value = {
-      id = openstack_compute_instance_v2.load_balancer.0.id
-      ip = openstack_compute_instance_v2.load_balancer.0.network.0.fixed_ip_v4
+      id = var.load_balancer_flavor_id != "" ? openstack_compute_instance_v2.load_balancer.0.id : ""
+      ip = var.load_balancer_flavor_id != "" ? openstack_compute_instance_v2.load_balancer.0.network.0.fixed_ip_v4 : ""
     }
 }

--- a/templates/lbl-cloud_config.yaml
+++ b/templates/lbl-cloud_config.yaml
@@ -17,9 +17,9 @@ write_files:
 
       defaults
         mode tcp
-        timeout connect 3000ms
-        timeout client 3000ms
-        timeout server 3000ms
+        timeout connect 5000ms
+        timeout client 5000ms
+        timeout server 5000ms
 
       backend k8_api_servers
         balance roundrobin

--- a/variables.tf
+++ b/variables.tf
@@ -39,8 +39,9 @@ variable "workers_security_groups" {
 }
 
 variable "load_balancer_flavor_id" {
-  description = "ID of the VM flavor of the load balancer sitting in front of the masters"
+  description = "ID of the VM flavor of the load balancer sitting in front of the masters. If set to the empty string, a load balancer will not be provisioned."
   type = string
+  default = ""
 }
 
 variable "load_balancer_security_groups" {


### PR DESCRIPTION
Made dedicated master api load balancer optional even with multiple master pending on a vm flavor for the load balancer being passed or not.

